### PR TITLE
fix(dropdown): update from competency id to competency name and fixed level number mismatch

### DIFF
--- a/src/components/questionBank/SelectComeptency.tsx
+++ b/src/components/questionBank/SelectComeptency.tsx
@@ -23,7 +23,11 @@ const SelectComeptency = () => {
         </p>
         <SelectTag
           options={competencyArray}
-          value={currentCompetency}
+          // value={currentCompetency}
+          value={
+            competencyArray.find((comp) => comp.value === currentCompetency)
+              ?.label ?? ''
+          }
           onChange={(option) => {
             if (typeof option == 'number') {
               setCurrentCompetency(option);

--- a/src/components/wpcasOverView/Questions.tsx
+++ b/src/components/wpcasOverView/Questions.tsx
@@ -42,7 +42,7 @@ const Questions = ({
           return (
             <div className='my-3' key={index + 1}>
               <p className='font-Outfit  text-base font-medium leading-[130%] text-black'>
-                Level {index + 1} : {data.competencyLevelName}
+                Level: {data.competencyLevelNumber}
               </p>
 
               <p className='font-Outfit mt-2 text-base font-normal leading-[130%] text-[#272728]'>


### PR DESCRIPTION
## Fix for issue: 
  ### 1. Showing competency id in place of competency name
  ### 2. Level number mismatch under Questions section in Question Bank page

